### PR TITLE
feat: 디바이스, 미디어 받아오는 로직 분리

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,8 @@
+export default function NotFound() {
+  return (
+    <div style={{padding: '4rem', textAlign: 'center'}}>
+      <h1>404 - 페이지를 찾을 수 없습니다</h1>
+      <p>잘못된 경로이거나 존재하지 않는 페이지입니다.</p>
+    </div>
+  );
+}

--- a/src/app/rehearsal/page.tsx
+++ b/src/app/rehearsal/page.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import {useMediaStore} from '@/stores/mediaStore';
+import {useEffect, useRef, useState} from 'react';
+
+const ReharsalPage = () => {
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const audioRecorderRef = useRef<MediaRecorder | null>(null);
+  const videoBlobsRef = useRef<Blob[]>([]);
+  const audioBlobsRef = useRef<Blob[]>([]);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const [isRecording, setIsRecording] = useState(false);
+  const {mediaStream} = useMediaStore();
+
+  useEffect(() => {
+    if (videoRef.current) {
+      videoRef.current.srcObject = mediaStream;
+    }
+  }, [mediaStream]);
+
+  const startRecording = ({
+    mediaStream,
+    selectedMimeType,
+    mediaRecorderRef,
+  }: {
+    mediaStream: MediaStream;
+    selectedMimeType: string;
+    mediaRecorderRef: React.MutableRefObject<MediaRecorder | null>;
+  }) => {
+    if (!mediaStream) return;
+
+    try {
+      videoBlobsRef.current = [];
+      audioBlobsRef.current = [];
+
+      mediaRecorderRef.current = new MediaRecorder(mediaStream, {
+        mimeType: selectedMimeType,
+        videoBitsPerSecond: 300000,
+      });
+
+      const audioOnlyStream = new MediaStream(mediaStream.getAudioTracks());
+
+      audioRecorderRef.current = new MediaRecorder(audioOnlyStream, {
+        mimeType: 'audio/webm',
+      });
+
+      mediaRecorderRef.current.ondataavailable = (event: BlobEvent) => {
+        if (event.data && event.data.size > 0) {
+          videoBlobsRef.current.push(event.data);
+        }
+      };
+
+      audioRecorderRef.current.ondataavailable = (event: BlobEvent) => {
+        if (event.data && event.data.size > 0) {
+          audioBlobsRef.current.push(event.data);
+        }
+      };
+    } catch (error) {
+      console.error('Error starting recording:', error);
+    }
+  };
+
+  const stopRecording = async ({
+    mediaRecorderRef,
+  }: {
+    mediaRecorderRef: React.MutableRefObject<MediaRecorder | null>;
+  }) => {
+    if (!mediaRecorderRef.current || !audioRecorderRef.current) return;
+
+    await Promise.all([
+      new Promise<void>((resolve) => {
+        mediaRecorderRef.current!.onstop = () => resolve();
+        mediaRecorderRef.current!.stop();
+      }),
+      new Promise<void>((resolve) => {
+        audioRecorderRef.current!.onstop = () => resolve();
+        audioRecorderRef.current!.stop();
+      }),
+    ]);
+
+    if (videoBlobsRef.current.length > 0) {
+      const blob = new Blob(videoBlobsRef.current, {type: 'video/webm'});
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.style.display = 'none';
+      a.href = url;
+      a.download = 'recording_video_audio.webm';
+      document.body.appendChild(a);
+      a.click();
+      URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+    }
+
+    if (audioBlobsRef.current.length > 0) {
+      const blob = new Blob(audioBlobsRef.current, {type: 'audio/webm'});
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.style.display = 'none';
+      a.href = url;
+      a.download = 'recording_audio_only.webm';
+      document.body.appendChild(a);
+      a.click();
+      URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+    }
+
+    videoBlobsRef.current = [];
+    audioBlobsRef.current = [];
+  };
+
+  const handleStartClick = () => {
+    if (mediaStream) {
+      startRecording({
+        mediaStream,
+        selectedMimeType: 'video/webm;codecs=vp8',
+        mediaRecorderRef,
+      });
+      mediaRecorderRef.current?.start();
+      audioRecorderRef.current?.start();
+      setIsRecording(true);
+    }
+  };
+
+  const handleCloseClick = async () => {
+    await stopRecording({mediaRecorderRef});
+    setIsRecording(false);
+  };
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100vw',
+        height: '100vh',
+      }}
+    >
+      <video
+        ref={videoRef}
+        autoPlay
+        muted
+        playsInline
+        style={{borderRadius: '20px', height: '500px', width: '500px'}}
+      />
+      <div style={{display: 'flex', gap: '30px', margin: '10px 0'}}>
+        <button
+          onClick={handleStartClick}
+          disabled={isRecording}
+          style={{padding: '10px', background: 'skyblue', borderRadius: '4px', width: '200px'}}
+        >
+          시작
+        </button>
+        <button
+          onClick={handleCloseClick}
+          disabled={!isRecording}
+          style={{padding: '10px', background: 'skyblue', borderRadius: '4px', width: '200px'}}
+        >
+          종료
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ReharsalPage;

--- a/src/app/rehearsal/setting/_components/SelectDeviceBox.tsx
+++ b/src/app/rehearsal/setting/_components/SelectDeviceBox.tsx
@@ -1,31 +1,34 @@
 import React, {useState} from 'react';
 import styles from './SelectDeviceBox.module.css';
-
-type DeviceType = 'videoInput' | 'audioInput';
+import {useDeviceStore, type Device} from '@/stores/devicsStore';
 
 interface SelectDeviceBoxProps {
-  type: DeviceType;
-  deviceList: MediaDeviceInfo[] | undefined;
-  selected: MediaDeviceInfo | undefined;
-  onSelect: (type: DeviceType, device: MediaDeviceInfo) => void;
+  type: Device;
 }
 
-const SelectDeviceBox = ({type, deviceList, selected, onSelect}: SelectDeviceBoxProps) => {
+const DevicesKey = {
+  videoInput: 'videoInputDevices',
+  audioInput: 'audioInputDevices',
+} as const;
+
+const SelectDeviceBox = ({type}: SelectDeviceBoxProps) => {
+  const {devices, selectDevice, setSelectDevice} = useDeviceStore();
   const [open, setOpen] = useState(false);
 
   const handleItemClick = (device: MediaDeviceInfo) => {
-    onSelect(type, device);
+    setSelectDevice(type, device);
     setOpen((prev) => !prev);
   };
 
   return (
     <div className={styles.wrapper}>
       <button onClick={() => setOpen((prev) => !prev)} className={styles.selected}>
-        {selected?.label ?? `${type === 'videoInput' ? '카메라' : '마이크'}를 선택하세요`}
+        {selectDevice[type]?.label ?? `${type === 'videoInput' ? '카메라' : '마이크'}를 선택하세요`}
+        {type === 'audioInput' && ' (필수)'}
       </button>
-      {open && deviceList && (
+      {open && devices && (
         <ul className={styles.options}>
-          {deviceList.map((device) => (
+          {devices[DevicesKey[type]].map((device) => (
             <li key={device.deviceId} onClick={() => handleItemClick(device)}>
               {device.label}
             </li>

--- a/src/app/rehearsal/setting/page.tsx
+++ b/src/app/rehearsal/setting/page.tsx
@@ -1,197 +1,35 @@
 'use client';
 
-import {useEffect, useRef, useState} from 'react';
+import {useEffect, useRef} from 'react';
 import SelectDeviceBox from './_components/SelectDeviceBox';
-
-const getDevices = async () => {
-  const devicesList = await navigator.mediaDevices.enumerateDevices();
-  const videoInputDevices = devicesList.filter((device) => device.kind === 'videoinput');
-  const audioInputDevices = devicesList.filter((device) => device.kind === 'audioinput');
-  return {videoInputDevices, audioInputDevices};
-};
-
-type DeviceList = {
-  videoInputDevices: MediaDeviceInfo[];
-  audioInputDevices: MediaDeviceInfo[];
-};
-
-type SelectDevice = {
-  videoInput: MediaDeviceInfo | undefined;
-  audioInput: MediaDeviceInfo | undefined;
-};
+import {useRouter} from 'next/navigation';
+import {useMediaStore} from '@/stores/mediaStore';
+import {getMediaStream} from '@/utils/media';
+import {useDeviceStore} from '@/stores/devicsStore';
 
 const ReharsalSettingPage = () => {
-  const [deviceList, setDeviceList] = useState<DeviceList>();
-  const [selectDevice, setSelectDevice] = useState<SelectDevice>();
+  const router = useRouter();
   const videoRef = useRef<HTMLVideoElement | null>(null);
-  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
-  const audioRecorderRef = useRef<MediaRecorder | null>(null);
-  const videoAudioBlobsRef = useRef<Blob[]>([]);
-  const audioBlobsRef = useRef<Blob[]>([]);
-  const [isRecording, setIsRecording] = useState(false);
-  const [media, setMedia] = useState<MediaStream | null>(null);
+  const {setMediaStream} = useMediaStore();
+  const {selectDevice} = useDeviceStore();
+  const {videoInput, audioInput} = selectDevice;
 
   useEffect(() => {
-    const fetchDevices = async () => {
-      const devices = await getDevices();
-      setDeviceList(devices);
-      setSelectDevice({
-        videoInput: devices.videoInputDevices[0],
-        audioInput: devices.audioInputDevices[0],
-      });
-    };
-
-    fetchDevices();
-  }, []);
-
-  useEffect(() => {
-    const fetchMediaStream = async () => {
-      if (!selectDevice) return;
-
-      try {
-        const stream = await navigator.mediaDevices.getUserMedia({
-          video: {
-            width: {ideal: 1920},
-            height: {ideal: 1080},
-            frameRate: 30,
-            deviceId: selectDevice.videoInput?.deviceId
-              ? {exact: selectDevice.videoInput.deviceId}
-              : undefined,
-          },
-          audio: {
-            echoCancellation: true,
-            deviceId: selectDevice.audioInput?.deviceId
-              ? {exact: selectDevice.audioInput.deviceId}
-              : undefined,
-          },
-        });
-
-        setMedia(stream);
+    const setupStream = async () => {
+      const stream = await getMediaStream({videoInput, audioInput});
+      if (stream) {
+        setMediaStream(stream);
         if (videoRef.current) {
           videoRef.current.srcObject = stream;
         }
-      } catch (error) {
-        console.error('Error accessing media devices.', error);
       }
     };
 
-    fetchMediaStream();
-  }, [selectDevice]);
+    void setupStream();
+  }, []);
 
-  const startRecording = ({
-    media,
-    selectedMimeType,
-    mediaRecorderRef,
-  }: {
-    media: MediaStream;
-    selectedMimeType: string;
-    mediaRecorderRef: React.MutableRefObject<MediaRecorder | null>;
-  }) => {
-    if (!media) return;
-
-    try {
-      videoAudioBlobsRef.current = [];
-      audioBlobsRef.current = [];
-
-      mediaRecorderRef.current = new MediaRecorder(media, {
-        mimeType: selectedMimeType,
-        videoBitsPerSecond: 300000,
-      });
-
-      const audioOnlyStream = new MediaStream(media.getAudioTracks());
-
-      audioRecorderRef.current = new MediaRecorder(audioOnlyStream, {
-        mimeType: 'audio/webm',
-      });
-
-      mediaRecorderRef.current.ondataavailable = (event: BlobEvent) => {
-        if (event.data && event.data.size > 0) {
-          videoAudioBlobsRef.current.push(event.data);
-        }
-      };
-
-      audioRecorderRef.current.ondataavailable = (event: BlobEvent) => {
-        if (event.data && event.data.size > 0) {
-          audioBlobsRef.current.push(event.data);
-        }
-      };
-    } catch (error) {
-      console.error('Error starting recording:', error);
-    }
-  };
-
-  const stopRecording = async ({
-    mediaRecorderRef,
-  }: {
-    mediaRecorderRef: React.MutableRefObject<MediaRecorder | null>;
-  }) => {
-    if (!mediaRecorderRef.current || !audioRecorderRef.current) return;
-
-    await Promise.all([
-      new Promise<void>((resolve) => {
-        mediaRecorderRef.current!.onstop = () => resolve();
-        mediaRecorderRef.current!.stop();
-      }),
-      new Promise<void>((resolve) => {
-        audioRecorderRef.current!.onstop = () => resolve();
-        audioRecorderRef.current!.stop();
-      }),
-    ]);
-
-    if (videoAudioBlobsRef.current.length > 0) {
-      const blob = new Blob(videoAudioBlobsRef.current, {type: 'video/webm'});
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.style.display = 'none';
-      a.href = url;
-      a.download = 'recording_video_audio.webm';
-      document.body.appendChild(a);
-      a.click();
-      URL.revokeObjectURL(url);
-      document.body.removeChild(a);
-    }
-
-    if (audioBlobsRef.current.length > 0) {
-      const blob = new Blob(audioBlobsRef.current, {type: 'audio/webm'});
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.style.display = 'none';
-      a.href = url;
-      a.download = 'recording_audio_only.webm';
-      document.body.appendChild(a);
-      a.click();
-      URL.revokeObjectURL(url);
-      document.body.removeChild(a);
-    }
-
-    videoAudioBlobsRef.current = [];
-    audioBlobsRef.current = [];
-  };
-
-  const handleSelectDevice = (type: 'videoInput' | 'audioInput', device: MediaDeviceInfo) => {
-    setSelectDevice((prev) => ({
-      audioInput: prev?.audioInput,
-      videoInput: prev?.videoInput,
-      [type]: device,
-    }));
-  };
-
-  const handleStartClick = () => {
-    if (media) {
-      startRecording({
-        media,
-        selectedMimeType: 'video/webm;codecs=vp8',
-        mediaRecorderRef,
-      });
-      mediaRecorderRef.current?.start();
-      audioRecorderRef.current?.start();
-      setIsRecording(true);
-    }
-  };
-
-  const handleCloseClick = async () => {
-    await stopRecording({mediaRecorderRef});
-    setIsRecording(false);
+  const handleRehearsalStart = () => {
+    router.push('/rehearsal');
   };
 
   return (
@@ -203,40 +41,28 @@ const ReharsalSettingPage = () => {
         alignItems: 'center',
         width: '100vw',
         height: '100vh',
+        gap: '50px',
       }}
     >
-      <video ref={videoRef} autoPlay muted playsInline style={{borderRadius: '20px'}} />
-      <div style={{display: 'flex', gap: '30px', margin: '10px 0'}}>
-        <button
-          onClick={handleStartClick}
-          disabled={isRecording}
-          style={{padding: '10px', background: 'skyblue', borderRadius: '4px', width: '200px'}}
-        >
-          시작
-        </button>
-        <button
-          onClick={handleCloseClick}
-          disabled={!isRecording}
-          style={{padding: '10px', background: 'skyblue', borderRadius: '4px', width: '200px'}}
-        >
-          종료
-        </button>
-      </div>
-      <div style={{display: 'flex', gap: '30px'}}>
-        <SelectDeviceBox
-          type="videoInput"
-          deviceList={deviceList?.videoInputDevices}
-          selected={selectDevice?.videoInput}
-          onSelect={handleSelectDevice}
-        />
+      <video
+        ref={videoRef}
+        autoPlay
+        muted
+        playsInline
+        style={{borderRadius: '20px', height: '500px', width: '500px'}}
+      />
 
-        <SelectDeviceBox
-          type="audioInput"
-          deviceList={deviceList?.audioInputDevices}
-          selected={selectDevice?.audioInput}
-          onSelect={handleSelectDevice}
-        />
+      <div style={{display: 'flex', gap: '30px'}}>
+        <SelectDeviceBox type="videoInput" />
+        <SelectDeviceBox type="audioInput" />
       </div>
+
+      <button
+        onClick={handleRehearsalStart}
+        style={{width: '100px', padding: '10px', background: 'skyblue'}}
+      >
+        면접 시작
+      </button>
     </div>
   );
 };

--- a/src/stores/devicsStore.ts
+++ b/src/stores/devicsStore.ts
@@ -1,0 +1,46 @@
+import {getDevices} from '@/utils/device';
+import {create} from 'zustand';
+
+export type Device = 'videoInput' | 'audioInput';
+
+type Devices = {
+  videoInputDevices: MediaDeviceInfo[];
+  audioInputDevices: MediaDeviceInfo[];
+};
+
+export type SelectDevice = Record<Device, MediaDeviceInfo | undefined>;
+
+type DeviceStore = {
+  devices: Devices;
+  selectDevice: SelectDevice;
+  setDevices: (devices: Devices) => void;
+  setSelectDevice: (type: Device, device: MediaDeviceInfo) => void;
+};
+
+export const useDeviceStore = create<DeviceStore>((set) => {
+  const fetchAndSetDevices = async () => {
+    const devices = await getDevices();
+    set({devices});
+    set({
+      selectDevice: {
+        videoInput: devices.videoInputDevices[0],
+        audioInput: devices.audioInputDevices[0],
+      },
+    });
+  };
+
+  void fetchAndSetDevices();
+
+  return {
+    devices: {videoInputDevices: [], audioInputDevices: []},
+    selectDevice: {videoInput: undefined, audioInput: undefined},
+    setDevices: (devices) => set({devices}),
+    setSelectDevice: (type, device) =>
+      set((state) => ({
+        selectDevice: {
+          ...state.selectDevice,
+          [type]: device,
+        },
+      })),
+  };
+});

--- a/src/stores/mediaStore.ts
+++ b/src/stores/mediaStore.ts
@@ -1,0 +1,11 @@
+import {create} from 'zustand';
+
+type MediaStore = {
+  mediaStream: MediaStream | null;
+  setMediaStream: (stream: MediaStream) => void;
+};
+
+export const useMediaStore = create<MediaStore>((set) => ({
+  mediaStream: null,
+  setMediaStream: (stream) => set({mediaStream: stream}),
+}));

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -1,0 +1,7 @@
+export const getDevices = async () => {
+  const devices = await navigator.mediaDevices.enumerateDevices();
+  const videoInputDevices = devices.filter((device) => device.kind === 'videoinput');
+  const audioInputDevices = devices.filter((device) => device.kind === 'audioinput');
+
+  return {videoInputDevices, audioInputDevices};
+};

--- a/src/utils/media.ts
+++ b/src/utils/media.ts
@@ -1,0 +1,25 @@
+interface GetMediaStreamProps {
+  videoInput: MediaDeviceInfo | undefined;
+  audioInput: MediaDeviceInfo | undefined;
+}
+
+export const getMediaStream = async ({videoInput, audioInput}: GetMediaStreamProps) => {
+  try {
+    const mediaStream = await navigator.mediaDevices.getUserMedia({
+      video: {
+        width: {ideal: 1920},
+        height: {ideal: 1080},
+        frameRate: 30,
+        deviceId: videoInput?.deviceId ? {exact: videoInput.deviceId} : undefined,
+      },
+      audio: {
+        echoCancellation: true,
+        deviceId: audioInput?.deviceId ? {exact: audioInput.deviceId} : undefined,
+      },
+    });
+
+    return mediaStream;
+  } catch (error) {
+    console.error('미디어 디바이스 접속 에러', error);
+  }
+};


### PR DESCRIPTION
<!-- - 제목 : feat(issue 번호): 기능명
  ex) feat(17): pull request template 작성
  (확인 후 지워주세요) -->

## 🔎 작업 내용

- not-found 페이지 추가
- get MediaStream 유틸 분리
- get Device 유틸 분리
- device, media 스토어 생성
- setting 페이지와 rehearsal페이지 관심사 분리

## 🏞️ 이미지 첨부

<!-- <img src="파일주소" width="50%" height="50%"/> -->

## 🔧 앞으로의 과제

- 미디어 스트림에 대한 에러 핸들링 
- 사용자 권한 거부, 장치 없음 등 미디어 스트림 에러 케이스 분리 및 대응 로직 추가

## ➕ 이슈 링크
