### PR TITLE
fix: [로그인] nextConfig 설정 추가

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,6 +14,11 @@ const nextConfig = {
         ],
     },
     output: "standalone",
+    experimental: {
+        serverActions: {
+            allowedOrigins: ['localhost:3000', 'minari-official.com']
+        }
+    }
 };
 
 export default nextConfig;


### PR DESCRIPTION
## 🔎 작업 내용

- 도커 로그 >>  `x-forwarded-host` header with value `localhost:3000` does not match `origin` header with value `minari-official.com` from a forwarded Server Actions request. Aborting the action.
- nextConfig 파일 수정

## 🏞️ 이미지 첨부


## 🔧 앞으로의 과제


## ➕ 이슈 링크

