### PR TITLE
3차 배포

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,6 +14,11 @@ const nextConfig = {
         ],
     },
     output: "standalone",
+    experimental: {
+        serverActions: {
+            allowedOrigins: ['localhost:3000', 'minari-official.com']
+        }
+    }
 };
 
 export default nextConfig;


### PR DESCRIPTION
## 🔎 작업 내용

- staging -> 메인 배포

- [반영내역]
  - 도커 로그 >>  `x-forwarded-host` header with value `localhost:3000` does not match `origin` header with value `minari-official.com` from a forwarded Server Actions request. Aborting the action.
  - nextConfig 파일 수정

## 🏞️ 이미지 첨부


## 🔧 앞으로의 과제


## ➕ 이슈 링크



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restricted server actions to requests from specified origins, improving security for users accessing the application from approved domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->