### PR TITLE
hotfix: ssh 전체허용에서 깃허브 엑션 ip 사용할 때 만 추가하고 이미지 올라가면 제거

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
       - name: Login to Dockerhub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -54,30 +54,49 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Get Public IP
+        id: ip
+        uses: haythem/public-ip@v1.3
+
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Add GitHub Actions IP
+        run: |
+          aws ec2 authorize-security-group-ingress \
+              --group-id ${{ secrets.AWS_SECURITY_GROUP_ID }} \
+              --protocol tcp \
+              --port 22 \
+              --cidr ${{ steps.ip.outputs.ipv4 }}/32
+
       - name: Connect and Deploy
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.AWS_HOST }}
           username: ${{ secrets.AWS_USERNAME }}
           key: ${{secrets.AWS_KEY}}
-          port: 22
-          script:
-            docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
-            
+          script: docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+
             docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }}
-            
+
             docker stop ${{ secrets.DOCKER_IMAGE_NAME }} || true
-            
+
             docker rm ${{ secrets.DOCKER_IMAGE_NAME }} || true
-            
+
             docker network create app_network || true
-            
+
             docker run -d --name=${{ secrets.DOCKER_IMAGE_NAME }} --rm -p 3000:3000 ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_IMAGE_NAME }}
-            
+
             docker image prune -f
+
+      - name: Remove GitHub Actions IP
+        run: |
+          aws ec2 revoke-security-group-ingress \
+              --group-id ${{ secrets.AWS_SECURITY_GROUP_ID }} \
+              --protocol tcp \
+              --port 22 \
+              --cidr ${{ steps.ip.outputs.ipv4 }}/32


### PR DESCRIPTION


<!-- - 제목 : feat(issue 번호): 기능명
  ex) feat(17): pull request template 작성
  (확인 후 지워주세요) -->

## 🔎 작업 내용

- haythem/public-ip@v1.3 으로 Github Actions VM ip 주소 받아오기
- authorize-security-group-ingress 으로 보안 그룹의 tcp:22번 ssh 로 접근이 가능하도록 ip 승인
- 이미지 배포 종료 후 revoke-security-group-ingress 으로 ssh접근 가능했던 ip 제거

## 🏞️ 이미지 첨부

<!-- <img src="파일주소" width="50%" height="50%"/> -->

## 🔧 앞으로의 과제



## ➕ 이슈 링크


